### PR TITLE
Move code from init to awakeWithContext

### DIFF
--- a/WatchKitAnimationDemo WatchKit Extension/InterfaceController.swift
+++ b/WatchKitAnimationDemo WatchKit Extension/InterfaceController.swift
@@ -13,10 +13,9 @@ import Foundation
 class InterfaceController: WKInterfaceController {
 
     @IBOutlet weak var minionsFunImage: WKInterfaceImage!
-    
-    override init(context: AnyObject?) {
-        // Initialize variables here.
-        super.init(context: context)
+  
+    override func awakeWithContext(context: AnyObject?) {
+        super.awakeWithContext(context)
         
         minionsFunImage.setImageNamed("frame")
         


### PR DESCRIPTION
Thanks so much for the demo. Just tried it out and had to change the controller to use `awakWithContext` instead of `init`, as this changed since the early betas. This is compiling and running for me now, using _Xcode 6.2 Beta 3 (6C101)_.
